### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,12 +11,15 @@ how to :ref:`installation` the project.
 
 .. note::
 
-   This project is under active development.
+    This project is under active development.
+
+.. note::
+    Lumache has its documentation hosted on Read the Docs.
 
 Contents
 --------
 
 .. toctree::
 
-   usage
-   api
+    usage
+    api


### PR DESCRIPTION
Add sentence explaining Lumache's documentation is hosted on Read the Docs.